### PR TITLE
Add Segment SDK Metadata

### DIFF
--- a/Sources/SegmentBraze/BrazeDestination.swift
+++ b/Sources/SegmentBraze/BrazeDestination.swift
@@ -63,6 +63,8 @@ public class BrazeDestination: DestinationPlugin {
             apiKey: brazeSettings?.apiKey ?? "",
             endpoint: brazeSettings?.customEndpoint ?? ""
             )
+        configuration.api.addSDKMetadata([.segment])
+
         braze = Braze(configuration: configuration)
     }
     


### PR DESCRIPTION
* Add Segment metadata to the configuration when initializing the Braze SDK