### PR TITLE
Enable before and enrichment middlware pre-event execution 

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -5,7 +5,7 @@ import PackageDescription
 let package = Package(
   name: "braze-segment-swift",
   platforms: [
-    .iOS("13.0"),
+    .iOS("14.0"),
     .tvOS("11.0"),
   ],
   products: [

--- a/Sources/SegmentBraze/BrazeDestination.swift
+++ b/Sources/SegmentBraze/BrazeDestination.swift
@@ -67,6 +67,7 @@ public class BrazeDestination: DestinationPlugin, VersionedPlugin {
   /// The Braze instance.
   public internal(set) var braze: Braze? = nil
 
+
   #if canImport(BrazeUI)
     /// The Braze in-app message UI, available when `automaticInAppMessageRegistrationEnabled` is
     /// set to `true` on the Segment dashboard.
@@ -286,8 +287,10 @@ public class BrazeDestination: DestinationPlugin, VersionedPlugin {
 
     let braze = Braze(configuration: configuration)
 
+      self.log(message: "check if can import BrazeUI")
     #if canImport(BrazeUI)
       if settings.automaticInAppMessageRegistrationEnabled == true {
+          self.log(message: "can import braze UI - setting in app message delegate")
         inAppMessageUI = BrazeInAppMessageUI()
         braze.inAppMessagePresenter = inAppMessageUI
       }

--- a/Sources/SegmentBraze/BrazeDestination.swift
+++ b/Sources/SegmentBraze/BrazeDestination.swift
@@ -1,6 +1,7 @@
 import BrazeKit
 import Foundation
 import Segment
+import os
 
 #if canImport(BrazeUI)
   import BrazeUI
@@ -102,6 +103,8 @@ public class BrazeDestination: DestinationPlugin, VersionedPlugin {
     self.additionalSetup = additionalSetup
   }
 
+    let logger = Logger(subsystem: "com.your_company.your_subsystem",
+              category: "your_category_name")
   // MARK: - Plugin
 
   public func update(settings: Settings, type: UpdateType) {
@@ -287,14 +290,24 @@ public class BrazeDestination: DestinationPlugin, VersionedPlugin {
 
     let braze = Braze(configuration: configuration)
 
-      self.log(message: "check if can import BrazeUI")
-    #if canImport(BrazeUI)
-      if settings.automaticInAppMessageRegistrationEnabled == true {
-          self.log(message: "can import braze UI - setting in app message delegate")
-        inAppMessageUI = BrazeInAppMessageUI()
-        braze.inAppMessagePresenter = inAppMessageUI
+      if #available(iOS 14.0, *) {
+          logger.info("Check if can if can import BrazeUI")
+      } else {
+          // Fallback on earlier versions
       }
-    #endif
+
+      if #available(iOS 14.0, *) {
+#if canImport(BrazeUI)
+          if settings.automaticInAppMessageRegistrationEnabled == true {
+              logger.info("Can import braze ui - set in app message presenter")
+
+              inAppMessageUI = BrazeInAppMessageUI()
+              braze.inAppMessagePresenter = inAppMessageUI
+          }
+#endif
+      } else {
+          // Fallback on earlier versions
+      }
 
     additionalSetup?(braze)
 

--- a/Sources/SegmentBraze/BrazeDestination.swift
+++ b/Sources/SegmentBraze/BrazeDestination.swift
@@ -47,6 +47,7 @@ import os
 /// See the Braze Swift SDK [documentation][1] for more information.
 ///
 /// [1]: https://braze-inc.github.io/braze-swift-sdk
+@available(iOS 14.0, *)
 public class BrazeDestination: DestinationPlugin, VersionedPlugin {
 
   // MARK: - Properties
@@ -103,8 +104,6 @@ public class BrazeDestination: DestinationPlugin, VersionedPlugin {
     self.additionalSetup = additionalSetup
   }
 
-    let logger = Logger(subsystem: "com.your_company.your_subsystem",
-              category: "your_category_name")
   // MARK: - Plugin
 
   public func update(settings: Settings, type: UpdateType) {
@@ -290,24 +289,25 @@ public class BrazeDestination: DestinationPlugin, VersionedPlugin {
 
     let braze = Braze(configuration: configuration)
 
-      if #available(iOS 14.0, *) {
-          logger.info("Check if can if can import BrazeUI")
-      } else {
-          // Fallback on earlier versions
-      }
+
 
       if #available(iOS 14.0, *) {
-#if canImport(BrazeUI)
+          print("[] create logger")
+          let logger = Logger(subsystem: "com.braze.segment",
+                              category: "com.braze.segment")
+
+          logger.info("Check if can if can import BrazeUI")
+
+        #if canImport(BrazeUI)
           if settings.automaticInAppMessageRegistrationEnabled == true {
               logger.info("Can import braze ui - set in app message presenter")
 
               inAppMessageUI = BrazeInAppMessageUI()
               braze.inAppMessagePresenter = inAppMessageUI
           }
-#endif
-      } else {
-          // Fallback on earlier versions
+    #endif
       }
+
 
     additionalSetup?(braze)
 

--- a/Sources/SegmentBraze/BrazeIDFAPlugin.swift
+++ b/Sources/SegmentBraze/BrazeIDFAPlugin.swift
@@ -1,0 +1,31 @@
+//
+//  BrazeIDFAPlugin.swift
+//  
+//
+//  Created by Nick Rudden on 28/09/2023.
+//
+
+import BrazeKit
+import Segment
+
+class BrazeIDFAPlugin: Plugin {
+    var type: PluginType = .enrichment
+    var analytics: Analytics?
+    var braze: Braze?
+
+    func execute<T>(event: T?) -> T? where T : RawEvent {
+        guard let braze else { return event }
+
+        if let context = event?.context?.dictionaryValue {
+          if let adTrackingEnabled = context[keyPath: "device.adTrackingEnabled"] as? Bool {
+            braze.set(adTrackingEnabled: adTrackingEnabled)
+          }
+            
+          if let idfa = context[keyPath: "device.advertisingId"] as? String {
+            braze.set(identifierForAdvertiser: idfa)
+          }
+        }
+
+        return event
+    }
+}


### PR DESCRIPTION
- Allow plugins attached to the `BrazeDestination` timeline to run and modify events before being sent to Braze
- This allows easy creation of a Plugin based braze debounce middleware as outlined here https://github.com/segmentio/segment-braze-mobile-middleware